### PR TITLE
Add a check for Sun zenith angle for Satpy plugins

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,94 @@
 Changelog
 =========
 
+%%version%% (unreleased)
+------------------------
+
+- Update changelog. [Panu Lahtinen]
+
+- Merge pull request #6 from ch-k/feature-publish-vars-param. [Panu
+  Lahtinen]
+
+  Satpy writer parameter to specify published values
+
+- Added sample to template. [Christian Kliche]
+
+- Configuration option to publish everything. [Christian Kliche]
+
+  Configuration of satpy_writer now supports "*" in parameter
+  "publish_vars".
+
+  Example 1:
+
+  publish_vars: "*"
+
+  Example 2:
+
+  publish_vars:
+    "*": ""
+    super_param: gatherer_time
+
+
+- Satpy writer parameter to specify published values. [Christian Kliche]
+
+  By default writer publishes only a fixed set of variables
+  in its posttroll message. If you want to forward attributes
+  that were received from a previous processing stage, you
+  can define a map called publish_vars. The keys denote variable
+  names in the message to be published. The value defines the
+  variable name in the received message.
+
+  publish_vars:
+    gatherer_time: gatherer_time
+
+  see example examples/flow_processor_satpy.yaml_template
+
+
+- Merge pull request #5 from ch-k/feature-param-proj-cache-dir. [Panu
+  Lahtinen]
+
+  Parameter cache_dir for satpy resampler
+
+- Parameter cache_dir for satpy resampler. [Christian Kliche]
+
+- Merge pull request #4 from ch-k/fix-satpy-resampler-radius. [Panu
+  Lahtinen]
+
+  Fix config of resampling radius in satpy_resampler
+
+- Reset 'radius_of_influence' at loop start. [Christian Kliche]
+
+- Fix config of resampling radius in satpy_resampler. [Christian Kliche]
+
+- Merge pull request #3 from ch-k/fix-non-xarray-dataset-attr. [Panu
+  Lahtinen]
+
+  Fix compatibility with satpy non-xarray branch
+
+- Fix compatibility with satpy non-xarray branch. [Christian Kliche]
+
+- Merge pull request #2 from ch-k/fix-writer-restart-params. [Panu
+  Lahtinen]
+
+  Fix writer restart with parameters
+
+- Fix writer restart with parameters. [Christian Kliche]
+
+- Merge pull request #1 from ch-k/feature-scene-reader-param. [Panu
+  Lahtinen]
+
+  Use metadata reader param for scene creation
+
+- Use metadata reader param for scene creation. [Christian Kliche]
+
+- Use the main logger from the fetch file. [Martin Raspaud]
+
+- Change setup.cfg's provides to reflect rpm name. [Martin Raspaud]
+
+- Adapt satpy_writer to xarray branch. [Martin Raspaud]
+
+- Check if file is local before fetching. [Martin Raspaud]
+
 v0.8.0 (2017-05-09)
 -------------------
 

--- a/trollflow_sat/satpy_resampler.py
+++ b/trollflow_sat/satpy_resampler.py
@@ -106,7 +106,7 @@ class Resampler(AbstractWorkflowComponent):
                 metadata = lcl.info
             metadata["product_config"] = product_config
             metadata["area_id"] = area_id
-            metadata["products"] = prod_list[area_id]['products']
+            metadata["products"] = glbl.info["products"]
             metadata["dataset_ids"] = dataset_ids
             self.logger.debug("Inserting lcl (area: %s, start_time: %s) "
                               "to writer's queue",

--- a/trollflow_sat/utils.py
+++ b/trollflow_sat/utils.py
@@ -151,6 +151,54 @@ def find_time_name(info):
     return None
 
 
+def bad_sunzen_range_satpy(product_config, group, composite, start_time):
+    """Check if Sun zenith angle is valid at the configured location.
+    SatPy version.
+    TODO: refactor with bad_sunzen_range()
+    """
+    # FIXME: check all areas within the group
+    area_id = product_config['groups'][group][0]
+    product_conf = \
+        product_config["product_list"][area_id]["products"][composite]
+
+    if ("sunzen_night_minimum" not in product_conf and
+            "sunzen_day_maximum" not in product_conf):
+        return False
+
+    if astronomy is None:
+        LOGGER.warning("Pyorbital not installed, unable to calculate "
+                       "Sun zenith angles!")
+        return False
+
+    if "sunzen_lon" not in product_conf and "sunzen_lat" not in product_conf:
+        LOGGER.warning("No 'sunzen_lon' or 'sunzen_lat' configured, "
+                       "can\'t check Sun elevation.")
+        return False
+
+    lon = product_conf["sunzen_lon"]
+    lat = product_conf["sunzen_lat"]
+    sunzen = astronomy.sun_zenith_angle(start_time, lon, lat)
+    LOGGER.debug("Sun zenith angle is %.2f degrees", sunzen)
+
+    try:
+        limit = product_conf["sunzen_night_minimum"]
+        if sunzen < limit:
+            return True
+        else:
+            return False
+    except KeyError:
+        pass
+
+    try:
+        limit = product_conf["sunzen_day_maximum"]
+        if sunzen > limit:
+            return True
+        else:
+            return False
+    except KeyError:
+        pass
+
+
 def bad_sunzen_range(area, product_config, area_id, prod, time_slot):
     """Check if Sun zenith angle is valid at the configured location."""
     product_conf = product_config["product_list"][area_id]["products"][prod]


### PR DESCRIPTION
Adds a check for Sun zenith angles for Satpy plugins. Composites that have `sunzen_day_maximum` *or* `sunzen_night_minimum` defined *and* *both* `sunzen_lon` and `sunzen_lat` defined are checked, and if not within the range are not created for that group of areas.

Fixes #10 