### PR TITLE
Embed overviews to saved images

### DIFF
--- a/examples/flow_processor_satpy.yaml_template
+++ b/examples/flow_processor_satpy.yaml_template
@@ -123,6 +123,9 @@ work:
               blockxsize: 512
               blockysize: 512
               compress: deflate
+              # Overviews (reduced resolution images) created from the full
+              # resolution data and embedded in the saved (GeoTIFF) files
+              # overviews: [2, 4, 8, 16, 32, 64, 128]
 
             # By default writer doesn't lock the compositor, but that
             #   can be done by setting use_lock to true

--- a/trollflow_sat/satpy_writer.py
+++ b/trollflow_sat/satpy_writer.py
@@ -297,6 +297,7 @@ def add_overviews(fnames, overviews, logger=None):
     except ImportError:
         if logger is not None:
             logger.error("Can't add overviews, install rasterio")
+        return
 
     if logger is not None:
         logger.info("Adding overviews")

--- a/trollflow_sat/satpy_writer.py
+++ b/trollflow_sat/satpy_writer.py
@@ -302,7 +302,8 @@ def add_overviews(fnames, overviews, logger=None):
         logger.info("Adding overviews")
 
     for fname in fnames:
-        dst = rasterio.open(fname, 'r+')
-        dst.build_overviews(overviews, Resampling.average)
-        dst.update_tags(ns='rio_overview', resampling='average')
-        dst.close()
+        with rasterio.open(fname, 'r+') as dst:
+            dst.build_overviews(overviews, Resampling.average)
+            dst.update_tags(ns='rio_overview', resampling='average')
+            dst.close()
+

--- a/trollflow_sat/satpy_writer.py
+++ b/trollflow_sat/satpy_writer.py
@@ -181,7 +181,7 @@ class DataWriter(Thread):
         """Add overviews (reduced resolution versions of image data) to the
         files.
         """
-        fnames = [msg.data['uri'] for msg in messages]
+        fnames = [msg.data['uri'] for msg in self.messages]
         overviews = self._save_settings['overviews']
         add_overviews(fnames, overviews, logger=self.logger)
 
@@ -290,7 +290,7 @@ class DataWriter(Thread):
 
 
 def add_overviews(fnames, overviews, logger=None):
-    """"""
+    """Add overviews to given files."""
     try:
         import rasterio
         from rasterio.enums import Resampling

--- a/trollflow_sat/satpy_writer.py
+++ b/trollflow_sat/satpy_writer.py
@@ -183,7 +183,7 @@ class DataWriter(Thread):
         """
         fnames = [msg.data['uri'] for msg in self.messages]
         overviews = self._save_settings['overviews']
-        add_overviews(fnames, overviews, logger=self.logger)
+        utils.add_overviews(fnames, overviews, logger=self.logger)
 
     def _send_messages(self):
         """Send currently collected messages about completed datasets."""
@@ -287,25 +287,3 @@ class DataWriter(Thread):
     def loop(self):
         """Property loop"""
         return self._loop
-
-
-def add_overviews(fnames, overviews, logger=None):
-    """Add overviews to given files."""
-    try:
-        import rasterio
-        from rasterio.enums import Resampling
-    except ImportError:
-        if logger is not None:
-            logger.error("Can't add overviews, install rasterio")
-        return
-
-    if logger is not None:
-        logger.info("Adding overviews")
-
-    for fname in fnames:
-        try:
-            with rasterio.open(fname, 'r+') as dst:
-                dst.build_overviews(overviews, Resampling.average)
-                dst.update_tags(ns='rio_overview', resampling='average')
-        except rasterio.RasterioIOError:
-            pass

--- a/trollflow_sat/satpy_writer.py
+++ b/trollflow_sat/satpy_writer.py
@@ -302,8 +302,9 @@ def add_overviews(fnames, overviews, logger=None):
         logger.info("Adding overviews")
 
     for fname in fnames:
-        with rasterio.open(fname, 'r+') as dst:
-            dst.build_overviews(overviews, Resampling.average)
-            dst.update_tags(ns='rio_overview', resampling='average')
-            dst.close()
-
+        try:
+            with rasterio.open(fname, 'r+') as dst:
+                dst.build_overviews(overviews, Resampling.average)
+                dst.update_tags(ns='rio_overview', resampling='average')
+        except rasterio.RasterioIOError:
+            pass

--- a/trollflow_sat/tests/test_satpy_writer.py
+++ b/trollflow_sat/tests/test_satpy_writer.py
@@ -184,8 +184,8 @@ class TestDataWriterContainer(unittest.TestCase):
         self.assertTrue(send_messages.called)
         self.assertTrue(add_overviews.called)
 
-    @patch('trollflow_sat.satpy_writer.add_overviews')
-    def test_add_overviews_method(self, add_overviews):
+    @patch('trollflow_sat.utils.add_overviews')
+    def test_add_overviews(self, add_overviews):
         logger = Mock()
         class mock_msg(object):
             def __init__(self, uri):
@@ -198,20 +198,6 @@ class TestDataWriterContainer(unittest.TestCase):
         self.writer.writer._add_overviews()
         add_overviews.assert_has_calls([call(['uri1', 'uri2'], None,
                                              logger=logger)])
-
-    def test_add_overviews_function(self):
-        r_open = Mock()
-        rasterio = Mock(RasterioIOError=BaseException, open=r_open)
-        import sys
-        sys.modules['rasterio'] = rasterio
-        from trollflow_sat.satpy_writer import add_overviews
-        logger = Mock()
-        fnames = ['a', 'b', 'c']
-        overviews = None
-        add_overviews(fnames, overviews, logger=logger)
-        r_open.has_calls([call('a', 'r+'),
-                          call('b', 'r+'),
-                          call('c', 'r+')])
 
     def test_send_messages(self):
         pub = Mock()

--- a/trollflow_sat/tests/test_satpy_writer.py
+++ b/trollflow_sat/tests/test_satpy_writer.py
@@ -172,13 +172,46 @@ class TestDataWriterContainer(unittest.TestCase):
         self.assertTrue(acquire_lock.called)
         self.assertTrue(release_locks.called)
 
+    @patch('trollflow_sat.satpy_writer.DataWriter._add_overviews')
     @patch('trollflow_sat.satpy_writer.DataWriter._send_messages')
     @patch('trollflow_sat.satpy_writer.compute_writer_results')
-    def test_compute(self, compute_writer_results, send_messages):
+    def test_compute(self, compute_writer_results, send_messages,
+                     add_overviews):
+        self.writer._save_settings['overviews'] = None
         self.writer.writer.data = 'foo'
         self.writer.writer._compute()
         self.assertTrue(compute_writer_results.called)
         self.assertTrue(send_messages.called)
+        self.assertTrue(add_overviews.called)
+
+    @patch('trollflow_sat.satpy_writer.add_overviews')
+    def test_add_overviews_method(self, add_overviews):
+        logger = Mock()
+        class mock_msg(object):
+            def __init__(self, uri):
+                self.data = {'uri': uri}
+        msg1 = mock_msg('uri1')
+        msg2 = mock_msg('uri2')
+        self.writer._save_settings['overviews'] = None
+        self.writer.writer.logger = logger
+        self.writer.writer.messages = [msg1, msg2]
+        self.writer.writer._add_overviews()
+        add_overviews.assert_has_calls([call(['uri1', 'uri2'], None,
+                                             logger=logger)])
+
+    def test_add_overviews_function(self):
+        r_open = Mock()
+        rasterio = Mock(RasterioIOError=BaseException, open=r_open)
+        import sys
+        sys.modules['rasterio'] = rasterio
+        from trollflow_sat.satpy_writer import add_overviews
+        logger = Mock()
+        fnames = ['a', 'b', 'c']
+        overviews = None
+        add_overviews(fnames, overviews, logger=logger)
+        r_open.has_calls([call('a', 'r+'),
+                          call('b', 'r+'),
+                          call('c', 'r+')])
 
     def test_send_messages(self):
         pub = Mock()

--- a/trollflow_sat/tests/test_utils.py
+++ b/trollflow_sat/tests/test_utils.py
@@ -22,9 +22,9 @@ import datetime as dt
 
 from collections import OrderedDict
 try:
-    from unittest.mock import patch, Mock
+    from unittest.mock import patch, Mock, call
 except ImportError:
-    from mock import patch, Mock
+    from mock import patch, Mock, call
 
 from trollflow_sat import utils
 from trollflow.utils import ordered_load
@@ -269,6 +269,20 @@ class TestUtils(unittest.TestCase):
         overpass.area_coverage.side_effect = AttributeError
         res = utils.covers(overpass, 'area1', 10, logger)
         self.assertTrue(logger.warning.called)
+
+    def test_add_overviews(self):
+        r_open = Mock()
+        rasterio = Mock(RasterioIOError=BaseException, open=r_open)
+        import sys
+        sys.modules['rasterio'] = rasterio
+        from trollflow_sat.utils import add_overviews
+        logger = Mock()
+        fnames = ['a', 'b', 'c']
+        overviews = None
+        add_overviews(fnames, overviews, logger=logger)
+        r_open.has_calls([call('a', 'r+'),
+                          call('b', 'r+'),
+                          call('c', 'r+')])
 
 
 def suite():

--- a/trollflow_sat/utils.py
+++ b/trollflow_sat/utils.py
@@ -284,3 +284,25 @@ def select_dict_items(src_dict, selection):
             else:
                 to_send[dest_key] = dest_key
     return to_send
+
+
+def add_overviews(fnames, overviews, logger=None):
+    """Add overviews to given files."""
+    try:
+        import rasterio
+        from rasterio.enums import Resampling
+    except ImportError:
+        if logger is not None:
+            logger.error("Can't add overviews, install rasterio")
+        return
+
+    if logger is not None:
+        logger.info("Adding overviews")
+
+    for fname in fnames:
+        try:
+            with rasterio.open(fname, 'r+') as dst:
+                dst.build_overviews(overviews, Resampling.average)
+                dst.update_tags(ns='rio_overview', resampling='average')
+        except rasterio.RasterioIOError:
+            pass


### PR DESCRIPTION
This PR adds the possibility to embed reduced size images, aka overviews, to GeoTIFF files and other formats supported by `rasterio`.