### PR TITLE
Bugfix default format settings

### DIFF
--- a/trollflow_sat/satpy_writer.py
+++ b/trollflow_sat/satpy_writer.py
@@ -233,6 +233,7 @@ class DataWriter(Thread):
                                              **kwargs)
                 except Exception:
                     self.logger.exception("Something went wrong when saving %s to %s.", prod, fname)
+                    continue
                 self.data.append(dset)
 
                 # Create message for this file

--- a/trollflow_sat/utils.py
+++ b/trollflow_sat/utils.py
@@ -23,8 +23,8 @@ except ImportError:
 
 PATTERN = "{time:%Y%m%d_%H%M}_{platform_name}_{areaname}_{productname}.png"
 
-FORMAT_DEFAULTS = {'writer': 'geotiff',
-                   'format': 'tif',
+FORMAT_DEFAULTS = {'writer': None,
+                   'format': None,
                    'fill_value': None}
 
 LOGGER = logging.getLogger(__name__)
@@ -97,6 +97,9 @@ def create_fnames(info, product_config, prod_id):
 
     fnames = []
     for fmt in formats:
+        # Default to TIFF
+        if pattern.endswith("{format}") and fmt["format"] is None:
+            fmt["format"] = "tif"
         info["format"] = fmt["format"]
         # Ensure non-unicode filename
         fnames.append(str(compose(pattern, info)))


### PR DESCRIPTION
If format settings were not given, geotiff was assumed. This also forced the writer to `'geotiff'`, and SatPy saved the file as geotiff even if the filename pattern had an format ending in it, e.g. `image.png`.

This PR changes the behaviour so that only filename ending (`'format'`) is set to `'tif'` (resulting in a geotiff file) if a) user haven't configured it, b) filename pattern ends in a `{format}` tag.